### PR TITLE
Repo moved. Use Storage SIG Yum Repos. Default to version 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Variables
 
 * `gluster_volumes` is a list of the volumes you want to create.
 * `glusterfs_cluster_name` must be set to the name of the group containing all the nodes of the GlusterFS cluster.
+* `glusterfs_version` is the Gluster version. Choices are '36', '37 or '38' which provides 3.6, 3.7 or 3.8, respectively. Default is '38'.
 
 See also
 --------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
 gluster_volumes: []
+gluster_version: 38

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,13 +12,5 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - role: AerisCloud.repos
-    remote_repositories:
-      centos6:
-        - http://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
-      centos7:
-        - http://download.gluster.org/pub/gluster/glusterfs/LATEST/CentOS/glusterfs-epel.repo
-    tags:
-      - glusterfs
   - role: AerisCloud.yum
 

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -1,13 +1,36 @@
+- name: "Install Storage SIG Yum Repos"
+  yum: >
+   name="centos-release-gluster{{ gluster_version }}"
+  tags:
+    - glusterfs
+
 - name: "Install GlusterFS"
   yum: >
    name={{ item }}
    state=present
-   enablerepo=glusterfs-epel
+   enablerepo=centos-gluster{{ gluster_version }}
+   disablerepo=base
   with_items:
     - glusterfs
     - glusterfs-cli
     - glusterfs-server
     - glusterfs-fuse
     - glusterfs-geo-replication
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version|int <= 6
+  tags:
+    - glusterfs
+
+- name: "Install GlusterFS"
+  yum: >
+   name={{ item }}
+   state=present
+   enablerepo=centos-gluster{{ gluster_version }}
+  with_items:
+    - glusterfs
+    - glusterfs-cli
+    - glusterfs-server
+    - glusterfs-fuse
+    - glusterfs-geo-replication
+  when: ansible_distribution == 'CentOS' and ansible_distribution_major_version|int >= 7
   tags:
     - glusterfs


### PR DESCRIPTION
- The glusterfs repo has moved to the CentOS Storage Special Interest Group (SIG).
  See [the CentOS wiki](https://wiki.centos.org/SpecialInterestGroup/Storage) and [GlusterFS install docs](http://gluster.readthedocs.io/en/latest/Install-Guide/Install/#for-red-hatcentos).
- Supports GlusterFS 3.6, 3.7 and 3.8.

Tested on CentOS 6.5 (GlusterFS v3.6 and v3.8) and 7.2 (v3.8)
